### PR TITLE
Reserve space for favicons, http -> https, fix #117

### DIFF
--- a/src/options/Options.vue
+++ b/src/options/Options.vue
@@ -30,7 +30,7 @@
             :checked="enabledMaps[map.name]"
             @change="setMapEnabled(map, $event.target.checked)"
           >
-          <img :src="'http://www.google.com/s2/favicons?domain=' + map.domain">
+          <img :src="'https://www.google.com/s2/favicons?domain=' + map.domain" width="16px">
           {{ map.name }}
         </label>
       </p>

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -14,7 +14,7 @@
         @click.left="openMapInCurrentTab(map)"
         @click.middle="openMapInOtherTab(map)"
       >
-        <img :src="'http://www.google.com/s2/favicons?domain=' + map.domain">
+        <img :src="'https://www.google.com/s2/favicons?domain=' + map.domain" width="16px">
         {{ map.name }}
       </p>
     </div>

--- a/src/popup/Popup.vue
+++ b/src/popup/Popup.vue
@@ -44,7 +44,7 @@ module.exports = {
 		this.open(map, mapUrl => 'window.location.href =' + JSON.stringify(mapUrl) + ';');
     },
     openMapInOtherTab(map) {
-      this.open(map, mapUrl => 'window.open(' + JSON.stringify(mapUrl) + ');');
+      this.open(map, mapUrl => 'window.open(' + JSON.stringify(mapUrl) + ', "_blank", "noreferrer");');
     },
     open(map, getCode) {
       chrome.tabs.query({


### PR DESCRIPTION
1. In Firefox, the popup has time to load before all the favicons load. Due to the fact that the favicons are initially empty, the site name twitches. Since all the favicons that Google gives away by default have a width of 16 pixels, I set this width in advance


<table>

<tr> 

<td>  

https://github.com/user-attachments/assets/87ce424c-5730-4f5c-8c72-edd630df4ca1 

<td>

https://github.com/user-attachments/assets/c22650d1-cede-4357-9a72-2c2851d7c9be

</tr>

</table>

2. The link to Google's favicon service now uses https
3. window.open() no longer transmit the Referer header when opening a link in a new tab #117



